### PR TITLE
setup development env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@ npm-debug.log
 # this depending on your deployment strategy.
 /priv/static/
 
-config/*.secret.exs
+# Sensitive Environment Variables
+.envrc

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,11 +1,14 @@
 use Mix.Config
 
 # Configure your database
+database_url =
+  System.get_env("DATABASE_URL") ||
+    raise """
+    environment variable DATABASE_URL is missing.
+    For example: ecto://USER:PASS@HOST/DATABASE
+    """
 config :tdp, Tdp.Repo,
-  username: "postgres",
-  password: "postgres",
-  database: "tdp_dev",
-  hostname: "localhost",
+  url: database_url,
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
 

--- a/config/prod.secret.exs
+++ b/config/prod.secret.exs
@@ -1,0 +1,38 @@
+# In this file, we load production configuration and secrets
+# from environment variables. You can also hardcode secrets,
+# although such is generally not recommended and you have to
+# remember to add this file to your .gitignore.
+use Mix.Config
+
+database_url =
+  System.get_env("DATABASE_URL") ||
+    raise """
+    environment variable DATABASE_URL is missing.
+    For example: ecto://USER:PASS@HOST/DATABASE
+    """
+
+config :tdp, Tdp.Repo,
+  # ssl: true,
+  url: database_url,
+  pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10")
+
+secret_key_base =
+  System.get_env("SECRET_KEY_BASE") ||
+    raise """
+    environment variable SECRET_KEY_BASE is missing.
+    You can generate one by calling: mix phx.gen.secret
+    """
+
+config :tdp, TdpWeb.Endpoint,
+  http: [:inet6, port: String.to_integer(System.get_env("PORT") || "4000")],
+  secret_key_base: secret_key_base
+
+# ## Using releases (Elixir v1.9+)
+#
+# If you are doing OTP releases, you need to instruct Phoenix
+# to start each relevant endpoint:
+#
+#     config :tdp, TdpWeb.Endpoint, server: true
+#
+# Then you can assemble a release by calling `mix release`.
+# See `mix help release` for more information.


### PR DESCRIPTION
- Checks prod.secret.exs back into git because its not a sensitive file
- Sets the development environment to also use the secret database url
- sets up .envrc